### PR TITLE
Add module sale_channel_white_label

### DIFF
--- a/sale_channel/models/sale_channel.py
+++ b/sale_channel/models/sale_channel.py
@@ -10,3 +10,4 @@ class SaleChannel(models.Model):
 
     name = fields.Char("Name", required=True)
     active = fields.Boolean(default=True)
+    partner_id = fields.Many2one("res.partner")

--- a/sale_channel/views/sale_channel.xml
+++ b/sale_channel/views/sale_channel.xml
@@ -19,6 +19,7 @@
                         </h1>
                         <group name="general_info" string="General information">
                             <field name="active" invisible="1" />
+                            <field name="partner_id" />
                         </group>
                     </sheet>
                 </form>

--- a/sale_channel_white_label/__init__.py
+++ b/sale_channel_white_label/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_channel_white_label/__manifest__.py
+++ b/sale_channel_white_label/__manifest__.py
@@ -1,0 +1,16 @@
+#  Copyright (c) Akretion 2021
+#  License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+{
+    "name": "Sale Channel White Label",
+    "summary": "Base for white label management",
+    "version": "14.0.1.0.0",
+    "category": "Generic Modules/Sale",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "website": "https://github.com/akretion/sale-import",
+    "depends": ["sale_channel"],
+    "license": "AGPL-3",
+    "data": [
+        "views/sale_channel.xml",
+    ],
+    "installable": True,
+}

--- a/sale_channel_white_label/models/__init__.py
+++ b/sale_channel_white_label/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_channel

--- a/sale_channel_white_label/models/sale_channel.py
+++ b/sale_channel_white_label/models/sale_channel.py
@@ -1,0 +1,11 @@
+#  Copyright (c) Akretion 2021
+#  License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+from odoo import fields, models
+
+
+class SaleChannel(models.Model):
+    _inherit = "sale.channel"
+
+    is_white_label = fields.Boolean(
+        help="Check this box if this channel comes from a white label partner"
+    )

--- a/sale_channel_white_label/readme/CONTRIBUTORS.rst
+++ b/sale_channel_white_label/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Florian da Costa <florian.dacosta@akretion.com>

--- a/sale_channel_white_label/readme/CREDITS.rst
+++ b/sale_channel_white_label/readme/CREDITS.rst
@@ -1,0 +1,3 @@
+The development of this module has been financially supported by:
+
+* Akretion <www.akretion.com>

--- a/sale_channel_white_label/readme/DESCRIPTION.rst
+++ b/sale_channel_white_label/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds the white label concept on sales channel
+It doesn't do much by itself, it is a base for other modules that could implement custom
+logic about white label orders management.

--- a/sale_channel_white_label/views/sale_channel.xml
+++ b/sale_channel_white_label/views/sale_channel.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+        <record id="sale_channel_view_form" model="ir.ui.view">
+            <field name="model">sale.channel</field>
+            <field name="inherit_id" ref="sale_channel.sale_channel_view_form" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="attributes">
+                    <attribute
+                    name="attrs"
+                >{'required': [('is_white_label', '=', True)]}</attribute>
+                </field>
+                <field name="partner_id" position="after">
+                    <field name="is_white_label" />
+                </field>
+            </field>
+        </record>
+
+</odoo>

--- a/setup/sale_channel_white_label/odoo/addons/sale_channel_white_label
+++ b/setup/sale_channel_white_label/odoo/addons/sale_channel_white_label
@@ -1,0 +1,1 @@
+../../../../sale_channel_white_label

--- a/setup/sale_channel_white_label/setup.py
+++ b/setup/sale_channel_white_label/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Add partner_id in main sale_channel module.
I leave it optional (not mandatory) but I think it is kind of a basic information.
In demo data, we have amazon for instance, I guess one could want to do some specific stuff with amazon and would need the partner on the channel.

Also, I create a sale_channel_white_label, even if the module is really empty for now.
I think channel is a good way to sell order for other brands, this is the way we've always done it for SD and it seems fine.

I guess with time, and maybe with other customers needing this, we could add some generic stuff in it, that is why I propose the module here instead of putting it in custom modules of the project.