### PR TITLE
Make exception rules unactived by default + add the no update flag to…

### DIFF
--- a/sale_import_base/data/sale_exception.xml
+++ b/sale_import_base/data/sale_exception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
+<odoo noupdate="1">
     <record id="exc_wrong_total_amount" model="exception.rule">
         <field name="name">Inconsistent total amounts</field>
         <field
@@ -7,6 +7,7 @@
         >The amount computed in Odoo doesn't match with the imported total amount.
 There is an error related to tax calculations.</field>
         <field name="sequence">50</field>
+        <field name="active" eval="False" />
         <field name="model">sale.order</field>
         <field
             name="code"
@@ -20,6 +21,7 @@ There is an error related to tax calculations.</field>
 There is an error related to the amount calculation.</field>
         <field name="sequence">50</field>
         <field name="model">sale.order</field>
+        <field name="active" eval="False" />
         <field
             name="code"
         >failed = obj.sale_channel_id.sale_orders_check_amounts_untaxed and abs(obj.amount_untaxed - obj.si_amount_untaxed) &gt;= 0.01</field>

--- a/sale_import_base/tests/test_sale_order_import.py
+++ b/sale_import_base/tests/test_sale_order_import.py
@@ -184,6 +184,8 @@ class TestSaleOrderImport(SaleImportCase):
         exception_wrong_total_amount = self.env.ref(
             "sale_import_base.exc_wrong_total_amount"
         )
+        # rule is unactive by default
+        exception_wrong_total_amount.sudo().write({"active": True})
         self.assertEqual(
             self.get_created_sales().detect_exceptions(),
             [exception_wrong_total_amount.id],


### PR DESCRIPTION
… make it customizable

I think put exception rules as inactive is a good practice, else it can mess with the tests of other modules and the user should probably be able to decide if he wants to use the rules or not.

@sebastienbeau 