### PR TITLE
[16.0][IMP] sale_import_base: add crm_team_id and methods to inherit sale.channel.importer

### DIFF
--- a/sale_import_base/models/sale_channel.py
+++ b/sale_import_base/models/sale_channel.py
@@ -20,6 +20,7 @@ class SaleChannel(models.Model):
         "(technical) Check total amounts against imported values"
     )
     pricelist_id = fields.Many2one("product.pricelist", string="Pricelist")
+    crm_team_id = fields.Many2one("crm.team")
     confirm_order = fields.Boolean(help="Confirm order after import")
     invoice_order = fields.Boolean(help="Generate invoice after import")
     internal_naming_method = fields.Selection(

--- a/sale_import_base/models/sale_channel_importer.py
+++ b/sale_import_base/models/sale_channel_importer.py
@@ -188,6 +188,13 @@ class SaleChannelImporter(models.TransientModel):
             ]
         )
         if not product:
+            product = self.env["product.product"].search(
+                [
+                    ("default_code", "=", line_data["product_code"]),
+                    ("product_tmpl_id.company_id", "=", False),
+                ]
+            )
+        if not product:
             raise ValidationError(
                 _(
                     "There is no active product with the Internal Reference %(code)s "
@@ -197,15 +204,8 @@ class SaleChannelImporter(models.TransientModel):
             )
         elif len(product) > 1:
             raise ValidationError(
-                _(
-                    "%(product_num)s products found for the code %(code)s and related "
-                    "to the company %(company)s."
-                )
-                % {
-                    "product_num": len(product),
-                    "code": line_data["product_code"],
-                    "company": company_id.name,
-                }
+                _("%(product_num)s products found for the code %(code)s.")
+                % {"product_num": len(product), "code": line_data["product_code"]}
             )
         vals = {
             "product_id": product.id,

--- a/sale_import_base/views/sale_channel_view.xml
+++ b/sale_import_base/views/sale_channel_view.xml
@@ -6,25 +6,28 @@
         <field name="inherit_id" ref="sale_channel.sale_channel_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='general_info']" position="after">
-                <group name="sale_import_base" string="Sale Import Parameters">
-                    <field name="internal_naming_method" />
-                    <field name="pricelist_id" />
-                    <field name="allow_match_on_email" />
-                    <field name="confirm_order" />
-                    <field
-                        name="invoice_order"
-                        attrs="{'invisible': [('confirm_order', '=', False)]}"
-                    />
-                </group>
-                <group name="check_amounts" string="Check imported values">
-                    <field
-                        name="sale_orders_check_amounts_untaxed"
-                        string="Untaxed amounts"
-                    />
-                    <field
-                        name="sale_orders_check_amounts_total"
-                        string="Total amounts"
-                    />
+                <group>
+                    <group name="sale_import_base" string="Sale Import Parameters">
+                        <field name="internal_naming_method" />
+                        <field name="pricelist_id" />
+                        <field name="crm_team_id" />
+                        <field name="allow_match_on_email" />
+                        <field name="confirm_order" />
+                        <field
+                            name="invoice_order"
+                            attrs="{'invisible': [('confirm_order', '=', False)]}"
+                        />
+                    </group>
+                    <group name="check_amounts" string="Check imported values">
+                        <field
+                            name="sale_orders_check_amounts_untaxed"
+                            string="Untaxed amounts"
+                        />
+                        <field
+                            name="sale_orders_check_amounts_total"
+                            string="Total amounts"
+                        />
+                    </group>
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
PR extracted from the original #83 to start pushing sale_import_base to OCA already with these modifications :

- add field crm_team_id
- add methods to inherit better sale.channel.importer
- add this last change on product search debated [here](https://github.com/akretion/sale-import/issues/84) and [here](https://github.com/akretion/sale-import/issues/84) (needed after removing dependence on product_code_unique)

@bealdav @florian-dacosta @sebastienbeau 