### PR TITLE
sale_import_base: be v16 ready

### DIFF
--- a/sale_import_base/__manifest__.py
+++ b/sale_import_base/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Import Base",
     "summary": "Base for importing Sale Orders through a JSON file format",
-    "version": "14.0.1.1.0",
+    "version": "14.0.2.0.0",
     "category": "Generic Modules/Sale",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/akretion/sale-import",

--- a/sale_import_base/migrations/14.0.2.0.0/pre-migration.py
+++ b/sale_import_base/migrations/14.0.2.0.0/pre-migration.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Akretion France (http://www.akretion.com/)
+# @author: Raphaël Reverdy <raphael.reverdy@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(env.cr, "payment_acquirer", "ref"):
+        # in v16
+        # payment_acquirer is renamed payment_provider
+        # and there is another different "code" field on payment_provider
+        # in sale_import_base (v16) the code field is now ref
+        # but without migration script
+        # therefore, we change it here to be future proof.
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "payment.aquirer",
+                    "payment_acquirer",
+                    "code",
+                    "ref",
+                ),
+            ],
+        )

--- a/sale_import_base/models/payment_acquirer.py
+++ b/sale_import_base/models/payment_acquirer.py
@@ -8,6 +8,9 @@ from odoo import fields, models
 class PaymentAcquirer(models.Model):
     _inherit = "payment.acquirer"
 
-    code = fields.Char()
+    # code is renamed in ref in v16
+    # we keep it as is, to keep compatibility only in v14
+    code = fields.Char(string="code", related="ref")
+    ref = fields.Char()
 
-    _sql_constraints = [("uniq_code", "uniq(code)", "The Acquirer code must be uniq")]
+    _sql_constraints = [("uniq_ref", "uniq(ref)", "The Acquirer ref must be uniq")]


### PR DESCRIPTION
code is renamed ref in v16
but there is also a code in the same table in v16
this code prevent an openupgrade failing because of already existing column (code)