### PR TITLE
[14.0] [ IMP] sale_import_base make adresses archiving configurable

### DIFF
--- a/sale_import_base/components/importer_sale_channel.py
+++ b/sale_import_base/components/importer_sale_channel.py
@@ -46,11 +46,11 @@ class ImporterSaleChannel(Component):
         return self._run(self.collection.data_str)
 
     def _prepare_sale_vals(self, data):
+        channel = self.env["sale.channel"].browse(self.collection.record_id)
         partner = self._process_partner(data["address_customer"])
         address_invoice, address_shipping = self._process_addresses(
-            partner, data["address_invoicing"], data["address_shipping"]
+            partner, data["address_invoicing"], data["address_shipping"], channel
         )
-        channel = self.env["sale.channel"].browse(self.collection.record_id)
         so_vals = {
             "partner_id": partner.id,
             "partner_invoice_id": address_invoice.id,
@@ -147,9 +147,13 @@ class ImporterSaleChannel(Component):
                 result["state_id"] = state.id
         return result
 
-    def _process_addresses(self, parent, address_invoice, address_shipping):
-        vals_addr_invoice = self._prepare_partner(address_invoice, parent.id, True)
-        vals_addr_shipping = self._prepare_partner(address_shipping, parent.id, True)
+    def _process_addresses(self, parent, address_invoice, address_shipping, channel):
+        vals_addr_invoice = self._prepare_partner(
+            address_invoice, parent.id, channel.auto_archive_addresses
+        )
+        vals_addr_shipping = self._prepare_partner(
+            address_shipping, parent.id, channel.auto_archive_addresses
+        )
         if vals_addr_invoice == vals_addr_shipping:
             # not technically correct for the shipping addr, but this shouldn't matter
             vals_addr_invoice["type"] = "invoice"

--- a/sale_import_base/components/importer_sale_channel.py
+++ b/sale_import_base/components/importer_sale_channel.py
@@ -49,7 +49,7 @@ class ImporterSaleChannel(Component):
         channel = self.env["sale.channel"].browse(self.collection.record_id)
         partner = self._process_partner(data["address_customer"])
         address_invoice, address_shipping = self._process_addresses(
-            partner, data["address_invoicing"], data["address_shipping"], channel
+            partner, data["address_invoicing"], data["address_shipping"], channel.auto_archive_address
         )
         so_vals = {
             "partner_id": partner.id,
@@ -147,12 +147,12 @@ class ImporterSaleChannel(Component):
                 result["state_id"] = state.id
         return result
 
-    def _process_addresses(self, parent, address_invoice, address_shipping, channel):
+    def _process_addresses(self, parent, address_invoice, address_shipping, archive_address=True):
         vals_addr_invoice = self._prepare_partner(
-            address_invoice, parent.id, channel.auto_archive_addresses
+            address_invoice, parent.id, archive_address
         )
         vals_addr_shipping = self._prepare_partner(
-            address_shipping, parent.id, channel.auto_archive_addresses
+            address_shipping, parent.id, channel.archive_address
         )
         if vals_addr_invoice == vals_addr_shipping:
             # not technically correct for the shipping addr, but this shouldn't matter

--- a/sale_import_base/components/importer_sale_channel.py
+++ b/sale_import_base/components/importer_sale_channel.py
@@ -49,7 +49,10 @@ class ImporterSaleChannel(Component):
         channel = self.env["sale.channel"].browse(self.collection.record_id)
         partner = self._process_partner(data["address_customer"])
         address_invoice, address_shipping = self._process_addresses(
-            partner, data["address_invoicing"], data["address_shipping"], channel.auto_archive_address
+            partner,
+            data["address_invoicing"],
+            data["address_shipping"],
+            channel.auto_archive_addresses,
         )
         so_vals = {
             "partner_id": partner.id,
@@ -147,12 +150,14 @@ class ImporterSaleChannel(Component):
                 result["state_id"] = state.id
         return result
 
-    def _process_addresses(self, parent, address_invoice, address_shipping, archive_address=True):
+    def _process_addresses(
+        self, parent, address_invoice, address_shipping, archive_addresses=True
+    ):
         vals_addr_invoice = self._prepare_partner(
-            address_invoice, parent.id, archive_address
+            address_invoice, parent.id, archive_addresses
         )
         vals_addr_shipping = self._prepare_partner(
-            address_shipping, parent.id, channel.archive_address
+            address_shipping, parent.id, archive_addresses
         )
         if vals_addr_invoice == vals_addr_shipping:
             # not technically correct for the shipping addr, but this shouldn't matter

--- a/sale_import_base/models/sale_channel.py
+++ b/sale_import_base/models/sale_channel.py
@@ -13,6 +13,10 @@ class SaleChannel(models.Model):
     _inherit = "sale.channel"
 
     allow_match_on_email = fields.Boolean("Allow customer match on email")
+    # default = True to be backward compatible as much as possible
+    auto_archive_addresses = fields.Boolean(
+        "Automatically archive partner's addresses", default=True
+    )
     sale_orders_check_amounts_untaxed = fields.Boolean(
         "(technical) Check untaxed amounts against imported values"
     )

--- a/sale_import_base/models/sale_channel.py
+++ b/sale_import_base/models/sale_channel.py
@@ -14,6 +14,8 @@ class SaleChannel(models.Model):
 
     allow_match_on_email = fields.Boolean("Allow customer match on email")
     # default = True to be backward compatible as much as possible
+    # NOTE : in V16 or sale_import_base backport V14 from V16 this
+    # field has been renamed archive_addresses
     auto_archive_addresses = fields.Boolean(
         "Automatically archive partner's addresses", default=True
     )

--- a/sale_import_base/tests/test_sale_order_import.py
+++ b/sale_import_base/tests/test_sale_order_import.py
@@ -58,7 +58,7 @@ class TestSaleOrderImport(SaleImportCase):
         """
         Base scenario: import Sale Order with standard data
         -> Create partner
-        -> Create delivery, shipping addresses in inactive state
+        -> Create delivery, shipping addresses in inactive state by default
         """
         partner_count = (
             self.env["res.partner"].with_context(active_test=False).search_count([])
@@ -73,6 +73,30 @@ class TestSaleOrderImport(SaleImportCase):
         self.assertEqual(sale.partner_shipping_id.active, False)
         self.assertEqual(sale.partner_invoice_id.type, "invoice")
         self.assertEqual(sale.partner_invoice_id.active, False)
+
+    def test_create_partner_no_archive(self):
+        """
+        Base scenario: import Sale Order with standard data
+        -> Create partner
+        -> Create delivery, shipping addresses remains active because
+            it has been configured with auto_archive_addresses = False
+        """
+        partner_count = (
+            self.env["res.partner"].with_context(active_test=False).search_count([])
+        )
+        chunk_vals = self.get_chunk_vals("all")
+        channel = self.env["sale.channel"].browse(chunk_vals["record_id"])
+        channel.auto_archive_addresses = False
+        self._helper_create_chunk(chunk_vals)
+        partner_count_after_import = (
+            self.env["res.partner"].with_context(active_test=False).search_count([])
+        )
+        self.assertEqual(partner_count_after_import, partner_count + 3)
+        sale = self.get_created_sales()
+        self.assertEqual(sale.partner_shipping_id.type, "delivery")
+        self.assertEqual(sale.partner_shipping_id.active, True)
+        self.assertEqual(sale.partner_invoice_id.type, "invoice")
+        self.assertEqual(sale.partner_invoice_id.active, True)
 
     def test_create_addresses_identical(self):
         """

--- a/sale_import_base/views/sale_channel.xml
+++ b/sale_import_base/views/sale_channel.xml
@@ -11,6 +11,7 @@
                         <field name="internal_naming_method" />
                         <field name="pricelist_id" />
                         <field name="allow_match_on_email" />
+                        <field name="auto_archive_addresses" />
                         <field name="confirm_order" />
                         <field
                             name="invoice_order"


### PR DESCRIPTION
Sometimes we do not want the partner's addresse to be archived. This allows it, per channel.

cc @hparfr 