### PR TITLE
[14.0] sale_channel: add fields type and company_id

### DIFF
--- a/sale_channel/__manifest__.py
+++ b/sale_channel/__manifest__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "data": [
         "security/ir.model.access.csv",
+        "security/sale_channel_security.xml",
         "views/sale_order.xml",
         "views/account_invoice.xml",
         "views/sale_channel.xml",

--- a/sale_channel/models/sale_channel.py
+++ b/sale_channel/models/sale_channel.py
@@ -16,3 +16,8 @@ class SaleChannel(models.Model):
         string="Sequence",
         help="If define sale order will use this sequence for it's name",
     )
+    company_id = fields.Many2one("res.company", default=lambda self: self.env.company)
+    channel_type = fields.Selection(
+        [],
+        help="Allows to use specific fields and actions for a specific channel's type",
+    )

--- a/sale_channel/security/sale_channel_security.xml
+++ b/sale_channel/security/sale_channel_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- multicomp rule -->
+    <record model="ir.rule" id="sale_channel_comp_rule">
+        <field name="name">Sale Channel multi-company</field>
+        <field name="model_id" ref="model_sale_channel" />
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>

--- a/sale_channel/views/sale_channel.xml
+++ b/sale_channel/views/sale_channel.xml
@@ -21,6 +21,11 @@
                             <field name="active" invisible="1" />
                             <field name="partner_id" />
                             <field name="sequence_id" />
+                            <field name="channel_type" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                            />
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
Fields used in sale_import_amazon, already merged in sale_channel v16: https://github.com/OCA/sale-channel/pull/17

cc @nayatec 